### PR TITLE
Updating googletrans version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docopt==0.6.2
 geojson==2.5.0
-googletrans==2.4.0
+googletrans==3.1.0a0
 idna==2.9
 pipreqs==0.4.10
 pyowm==2.10.0


### PR DESCRIPTION
Update to version googletrans==3.1.0a0

"Announcement: Temporary Fix For (AttributeError: 'NoneType' object has no attribute 'group') in 3.0.0 Version "

check at the oficial repository: github.com/ssut/py-googletrans/issues/280